### PR TITLE
Query handling

### DIFF
--- a/edr_server/collection.py
+++ b/edr_server/collection.py
@@ -12,5 +12,5 @@ class CollectionsHandler(Handler):
         collections_path = config.config.collections_json_path()
         with open(collections_path, "r") as ojfh:
             json_data = json.load(ojfh)
-            # A Python dict will be sent with Content-Type: aaplication/json in the headers.
+            # A Python dict will be sent with Content-Type: application/json in the headers.
             self.write(dict(json_data))

--- a/edr_server/handlers.py
+++ b/edr_server/handlers.py
@@ -111,10 +111,15 @@ class Handler(RequestHandler):
         self.query_parameters = QueryParameters()
 
     def get(self, collection_name):
-        """Handle a get request for data from EDR. Returned as JSON, unless the query specifies otherwise."""
+        """
+        Handle a get request for data from EDR.
+        Returned as JSON, unless the query specifies otherwise.
+
+        """
         self.handle_parameters()
 
     def handle_parameters(self):
+        """Translate EDR concepts in the query arguments into standard Python objects."""
         for key in self.request.query_arguments.keys():
             param_vals = self.get_arguments(key)
             self.query_parameters.handle_parameter(key, param_vals)

--- a/etc/config.yml
+++ b/etc/config.yml
@@ -1,4 +1,3 @@
 collections:
   json:
-    # path: "../etc/data/empty_test_collections.json"
-    path: "/Users/dpeterk/github/informatics-lab/3DT/edr_demo/static/json/collections.json"
+    path: "../etc/data/empty_test_collections.json"


### PR DESCRIPTION
Add more routes to the EDR Server Application, and add query parameter parsing. All forms of EDR query (including data requests such as `position` or `cube`, the user-aid `locations` and the binary-object provider `items`) now have a basic handler. EDR also defines a set of specific query string keys, as well as definitions of how values for these keys can be supplied, and this PR introduces a handler to parse these EDR query strings too.