### PR TITLE
Executable script for running EDR server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ pip install tornado
 
 ## Using it
 
-Execute the Python script `server.py`. This will kick off a tornado web server (running on localhost and on port 8808 by default, which was chosen at random) that runs the EDR Server. For example:
+Run the executable Python script `bin/run_server.py`. This will kick off a tornado web server (running on localhost and on port 8808 by default, which was chosen at random) that runs the EDR Server. For example:
 
 ```bash
-$ python -m edr_server.server
+$ ./bin/run_server.py
 Listening on port 8808...
 ```
 

--- a/bin/run_server.py
+++ b/bin/run_server.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import logging
+
+from edr_server.server import make_app
+import tornado.ioloop
+from tornado.options import options, define
+
+
+APP_LOGGER = logging.getLogger("tornado.application")
+
+define("port", default=8808, help="port to listen on")
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    logging.getLogger().setLevel(logging.ERROR)
+    logging.getLogger("tornado").setLevel(options.logging.upper())
+
+    app = make_app()
+    app.listen(options.port)
+    APP_LOGGER.info(f"Listening on port {options.port}...")
+
+    tornado.ioloop.IOLoop.current().start()

--- a/edr_server/server.py
+++ b/edr_server/server.py
@@ -1,8 +1,4 @@
-import logging
-
-import tornado.ioloop
 from clean_air.data.storage import create_metadata_store
-from tornado.options import options, define
 from tornado.web import Application, url
 
 from . import admin
@@ -10,8 +6,6 @@ from . import collection
 from . import handlers
 from .config import config
 from .paths import app_relative_path_to_absolute
-
-APP_LOGGER = logging.getLogger("tornado.application")
 
 
 def make_app():
@@ -40,17 +34,3 @@ def make_app():
         ],
         template_path=app_relative_path_to_absolute("templates"),
     )
-
-
-define("port", default=8808, help="port to listen on")
-
-if __name__ == "__main__":
-    logging.basicConfig()
-    logging.getLogger().setLevel(logging.ERROR)
-    logging.getLogger("tornado").setLevel(options.logging.upper())
-
-    app = make_app()
-    app.listen(options.port)
-    APP_LOGGER.info(f"Listening on port {options.port}...")
-
-    tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
Separate the application definition from the tornado webserver runner. The application definition remains in `edr_server/server.py` (but should perhaps be renamed to `app.py`?) and the code to run the webserver has been moved to `bin/run_server.py` (which is an executable). This has various benefits, notably being able to use relative imports within the library's codebase. 