### PR TITLE
Less greedy collections URL matching to avoid incorrect matches

### DIFF
--- a/edr_server/server/server.py
+++ b/edr_server/server/server.py
@@ -27,7 +27,7 @@ def make_app():
             url(r"/collections/(.*)/position", handlers.PositionHandler, name="position_query"),
             url(r"/collections/(.*)/radius", handlers.RadiusHandler),
             url(r"/collections/(.*)/trajectory", handlers.TrajectoryHandler),
-            url(r"/collections/(.*)\/?", collection.CollectionsHandler,
+            url(r"/collections/([^/]*)\/?", collection.CollectionsHandler,
                 {"collections_cache_path": collections_cache_path},
                 name="collection"),
             url(r"/collections\/?", collection.CollectionsHandler,


### PR DESCRIPTION
Some URLs that should return a 404 are being matched incorrectly by the `collections` handler and so returning a `collections` response. This tightens the URL matching for that handler to avoid this.

Fixes #13 