### PR TITLE
added type checking to SpatialExtent

### DIFF
--- a/edr_server/core/models/extents.py
+++ b/edr_server/core/models/extents.py
@@ -136,6 +136,10 @@ class SpatialExtent(EdrModel["SpatialExtent"]):
     bbox: shapely.geometry.Polygon
     crs: CrsObject = DEFAULT_CRS
 
+    def __post_init__(self):
+        if not (isinstance(self.bbox, Polygon)):
+            raise(TypeError(f'Expect polygon, received {type(self.bbox)}'))
+
     @classmethod
     def _prepare_json_for_init(cls, json_dict: JsonDict) -> JsonDict:
         crs = CrsObject.from_wkt(json_dict["crs_details"])

--- a/tests/unit/core/models/test_extents.py
+++ b/tests/unit/core/models/test_extents.py
@@ -1,9 +1,8 @@
 import unittest
 from datetime import datetime, timedelta
 
-from edr_server.core.models.extents import TemporalExtent
+from edr_server.core.models.extents import TemporalExtent, SpatialExtent
 from edr_server.core.models.time import DateTimeInterval, Duration
-
 
 class TemporalExtentTest(unittest.TestCase):
 
@@ -329,3 +328,17 @@ class TemporalExtentTest(unittest.TestCase):
         extent = TemporalExtent(values=datetimes, intervals=[dti1, dti2, dti3])
 
         self.assertEqual(expected_bounds, extent.bounds)
+
+class SpatialExtentTest(unittest.TestCase):
+
+    def test_type_checking(self):
+        """
+        GIVEN a non-polygon input
+        WHEN passed to SpatialExtent
+        THEN a TypeError is returned
+        Added due to https://metoffice.atlassian.net/browse/CAP-361
+        """
+        input = "bad input"
+
+        with self.assertRaisesRegex(TypeError, "Expect polygon, received <class 'str'>"):
+            SpatialExtent(input)


### PR DESCRIPTION
Added post_init method to SpatialExtent that raises a type error if something other than a Shapely Polygon is passed to the class. Added in response to this [ticket](https://metoffice.atlassian.net/browse/CAP-361).