### PR TITLE
added CRS type checking to SpatialExtent

### DIFF
--- a/edr_server/core/models/extents.py
+++ b/edr_server/core/models/extents.py
@@ -138,7 +138,9 @@ class SpatialExtent(EdrModel["SpatialExtent"]):
 
     def __post_init__(self):
         if not (isinstance(self.bbox, Polygon)):
-            raise(TypeError(f'Expect polygon, received {type(self.bbox)}'))
+            raise(TypeError(f'Expected polygon, received {type(self.bbox)}'))
+        if not (isinstance(self.crs, CrsObject)):
+            raise(TypeError(f'Expected CrsObject, received {type(self.crs)}'))
 
     @classmethod
     def _prepare_json_for_init(cls, json_dict: JsonDict) -> JsonDict:

--- a/edr_server/core/models/extents.py
+++ b/edr_server/core/models/extents.py
@@ -138,9 +138,9 @@ class SpatialExtent(EdrModel["SpatialExtent"]):
 
     def __post_init__(self):
         if not (isinstance(self.bbox, Polygon)):
-            raise(TypeError(f'Expected polygon, received {type(self.bbox)}'))
+            raise TypeError(f'Expected polygon, received {type(self.bbox)}')
         if not (isinstance(self.crs, CrsObject)):
-            raise(TypeError(f'Expected CrsObject, received {type(self.crs)}'))
+            raise TypeError(f'Expected CrsObject, received {type(self.crs)}')
 
     @classmethod
     def _prepare_json_for_init(cls, json_dict: JsonDict) -> JsonDict:

--- a/tests/unit/core/models/test_extents.py
+++ b/tests/unit/core/models/test_extents.py
@@ -332,7 +332,7 @@ class TemporalExtentTest(unittest.TestCase):
 
 class SpatialExtentTest(unittest.TestCase):
 
-    def test_type_checking_bbox(self):
+    def test_init_type_checking_bbox(self):
         """
         GIVEN a non-polygon input
         WHEN passed to SpatialExtent
@@ -344,7 +344,7 @@ class SpatialExtentTest(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "Expected polygon, received <class 'str'>"):
             SpatialExtent(input)
 
-    def test_type_checking_crs(self):
+    def test_init_type_checking_crs(self):
         """
         GIVEN a non-CrsObject input
         WHEN passed to SpatialExtent

--- a/tests/unit/core/models/test_extents.py
+++ b/tests/unit/core/models/test_extents.py
@@ -340,5 +340,5 @@ class SpatialExtentTest(unittest.TestCase):
         """
         input = "bad input"
 
-        with self.assertRaisesRegex(TypeError, "Expect polygon, received <class 'str'>"):
+        with self.assertRaisesRegex(TypeError, "Expected polygon, received <class 'str'>"):
             SpatialExtent(input)

--- a/tests/unit/core/models/test_extents.py
+++ b/tests/unit/core/models/test_extents.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
+from shapely.geometry import Polygon
 
 from edr_server.core.models.extents import TemporalExtent, SpatialExtent
 from edr_server.core.models.time import DateTimeInterval, Duration
@@ -331,7 +332,7 @@ class TemporalExtentTest(unittest.TestCase):
 
 class SpatialExtentTest(unittest.TestCase):
 
-    def test_type_checking(self):
+    def test_type_checking_bbox(self):
         """
         GIVEN a non-polygon input
         WHEN passed to SpatialExtent
@@ -342,3 +343,16 @@ class SpatialExtentTest(unittest.TestCase):
 
         with self.assertRaisesRegex(TypeError, "Expected polygon, received <class 'str'>"):
             SpatialExtent(input)
+
+    def test_type_checking_crs(self):
+        """
+        GIVEN a non-CrsObject input
+        WHEN passed to SpatialExtent
+        THEN a TypeError is returned
+        Added due to https://metoffice.atlassian.net/browse/CAP-362
+        """
+        poly = Polygon([[0, 0], [1, 0], [1, 1]])
+        input = "bad input"
+
+        with self.assertRaisesRegex(TypeError, "Expected CrsObject, received <class 'str'>"):
+            SpatialExtent(poly, input)


### PR DESCRIPTION
Added more type checking to the post_init method in SpatialExtent that raises a type error if something other than a `CrsObject` is passed to the class. Added in response to this [ticket](https://metoffice.atlassian.net/browse/CAP-362).