### PR TITLE
added type checking to TemporalExtent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ venv.bak/
 # PyCharm
 .idea
 
+# VSCode
+.vscode
+
 # Rope project settings
 .ropeproject
 

--- a/edr_server/core/models/extents.py
+++ b/edr_server/core/models/extents.py
@@ -45,15 +45,17 @@ class TemporalExtent(EdrModel["TemporalExtent"]):
 
     def __post_init__(self):
         if not isinstance(self.values, List):
-            raise TypeError(f'Expected List of values, received {type(self.values)}')
-        for value in self.values:
-            if not isinstance(value, datetime):
-                raise TypeError(f"Expected all datetime values, received value '{value}' of type {type(value)}")
+            raise TypeError(
+                f'Expected List of values, received {type(self.values)}')
+        if not all(isinstance((invalid_value := value), datetime) for value in self.values):
+            raise TypeError(
+                f"Expected all datetime values, received value '{invalid_value}' of type {type(invalid_value)}")
         if not isinstance(self.intervals, List):
-            raise TypeError(f'Expected List of intervals, received {type(self.intervals)}')
-        for interval in self.intervals:
-            if not isinstance(interval, DateTimeInterval):
-                raise TypeError(f"Expected all DateTimeIntervals, received value '{interval}' of type {type(interval)}")
+            raise TypeError(
+                f'Expected List of intervals, received {type(self.intervals)}')
+        if not all(isinstance((invalid_interval := interval), DateTimeInterval) for interval in self.intervals):
+            raise TypeError(
+                f"Expected all DateTimeIntervals, received value '{invalid_interval}' of type {type(invalid_interval)}")
         if not isinstance(self.trs, CrsObject):
             raise TypeError(f'Expected CrsObject, received {type(self.trs)}')
 
@@ -165,7 +167,8 @@ class SpatialExtent(EdrModel["SpatialExtent"]):
 
         if len(encoded_bbox) == 6:  # 3D bounding box
             min_x, min_y, min_z, max_x, max_y, max_z = encoded_bbox
-            coords = itertools.product((min_x, max_x), (min_y, max_y), (min_z, max_z))
+            coords = itertools.product(
+                (min_x, max_x), (min_y, max_y), (min_z, max_z))
             bbox = Polygon(coords)
 
         else:  # 2D bounding box
@@ -261,9 +264,11 @@ class Extents(EdrModel["Extents"]):
         if "spatial" in json_dict:
             kwargs["spatial"] = SpatialExtent.from_json(json_dict["spatial"])
         if "temporal" in json_dict:
-            kwargs["temporal"] = TemporalExtent.from_json(json_dict["temporal"])
+            kwargs["temporal"] = TemporalExtent.from_json(
+                json_dict["temporal"])
         if "vertical" in json_dict:
-            kwargs["vertical"] = VerticalExtent.from_json(json_dict["vertical"])
+            kwargs["vertical"] = VerticalExtent.from_json(
+                json_dict["vertical"])
 
         return kwargs
 

--- a/edr_server/core/models/extents.py
+++ b/edr_server/core/models/extents.py
@@ -252,7 +252,7 @@ class Extents(EdrModel["Extents"]):
     Based on
     https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/blob/546c338/standard/openapi/schemas/extent.yaml
     """
-    spatial: SpatialExtent
+    spatial: Optional[SpatialExtent] = None
     temporal: Optional[TemporalExtent] = None
     vertical: Optional[VerticalExtent] = None
 

--- a/edr_server/core/models/extents.py
+++ b/edr_server/core/models/extents.py
@@ -43,6 +43,20 @@ class TemporalExtent(EdrModel["TemporalExtent"]):
     intervals: List[DateTimeInterval] = dataclasses.field(default_factory=list)
     trs: CrsObject = DEFAULT_TRS
 
+    def __post_init__(self):
+        if not isinstance(self.values, List):
+            raise TypeError(f'Expected List of values, received {type(self.values)}')
+        for value in self.values:
+            if not isinstance(value, datetime):
+                raise TypeError(f"Expected all datetime values, received value '{value}' of type {type(value)}")
+        if not isinstance(self.intervals, List):
+            raise TypeError(f'Expected List of intervals, received {type(self.intervals)}')
+        for interval in self.intervals:
+            if not isinstance(interval, DateTimeInterval):
+                raise TypeError(f"Expected all DateTimeIntervals, received value '{interval}' of type {type(interval)}")
+        if not isinstance(self.trs, CrsObject):
+            raise TypeError(f'Expected CrsObject, received {type(self.trs)}')
+
     @classmethod
     def _prepare_json_for_init(cls, json_dict: JsonDict) -> JsonDict:
         json_dict["trs"] = CrsObject.from_wkt(json_dict["trs"])
@@ -137,9 +151,9 @@ class SpatialExtent(EdrModel["SpatialExtent"]):
     crs: CrsObject = DEFAULT_CRS
 
     def __post_init__(self):
-        if not (isinstance(self.bbox, Polygon)):
+        if not isinstance(self.bbox, Polygon):
             raise TypeError(f'Expected polygon, received {type(self.bbox)}')
-        if not (isinstance(self.crs, CrsObject)):
+        if not isinstance(self.crs, CrsObject):
             raise TypeError(f'Expected CrsObject, received {type(self.crs)}')
 
     @classmethod

--- a/edr_server/core/models/parameters.py
+++ b/edr_server/core/models/parameters.py
@@ -49,9 +49,12 @@ class Unit(EdrModel["Unit"]):
         if "symbol" in json_dict and isinstance(json_dict["symbol"], dict):
             json_dict["symbol"] = Symbol.from_json(json_dict["symbol"])
 
-        if "labels" in json_dict and isinstance(json_dict["label"], dict):
+        if "label" in json_dict and isinstance(json_dict["label"], dict):
             # Note, the field is called `label` in the serialised output, even though it can hold multiple values
             json_dict["label"] = LanguageMap.from_json(json_dict["label"])
+
+        if "label" in json_dict and isinstance(json_dict["label"], str):
+            json_dict["labels"] = json_dict.pop('label')
 
         return json_dict
 

--- a/edr_server/core/models/parameters.py
+++ b/edr_server/core/models/parameters.py
@@ -53,7 +53,7 @@ class Unit(EdrModel["Unit"]):
             # Note, the field is called `label` in the serialised output, even though it can hold multiple values
             json_dict["label"] = LanguageMap.from_json(json_dict["label"])
 
-        if "label" in json_dict and isinstance(json_dict["label"], str):
+        if "label" in json_dict and isinstance(json_dict["label"], (str, LanguageMap)):
             json_dict["labels"] = json_dict.pop('label')
 
         return json_dict

--- a/tests/unit/core/models/test_extents.py
+++ b/tests/unit/core/models/test_extents.py
@@ -5,6 +5,7 @@ from shapely.geometry import Polygon
 from edr_server.core.models.extents import TemporalExtent, SpatialExtent
 from edr_server.core.models.time import DateTimeInterval, Duration
 
+
 class TemporalExtentTest(unittest.TestCase):
 
     def test_bounds_no_values(self):
@@ -140,7 +141,8 @@ class TemporalExtentTest(unittest.TestCase):
 
         expected_bounds = None, dti1.end
 
-        extent = TemporalExtent(intervals=[dti1, dti2, dti3])  # There's deliberate overlap with the DateTimeIntervals
+        # There's deliberate overlap with the DateTimeIntervals
+        extent = TemporalExtent(intervals=[dti1, dti2, dti3])
 
         self.assertEqual(expected_bounds, extent.bounds)
 
@@ -151,7 +153,8 @@ class TemporalExtentTest(unittest.TestCase):
         WHEN TemporalExtent.bounds is accessed
         THEN the result contains the value of the earliest start date and None
         """
-        dti1 = DateTimeInterval(start=datetime(2020, 12, 30), duration=Duration(days=1))
+        dti1 = DateTimeInterval(start=datetime(
+            2020, 12, 30), duration=Duration(days=1))
         dti2 = DateTimeInterval(start=dti1.end, duration=Duration(days=2),
                                 recurrences=DateTimeInterval.INFINITE_RECURRENCES)
         dti3 = DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 2, 1))
@@ -170,8 +173,10 @@ class TemporalExtentTest(unittest.TestCase):
         WHEN TemporalExtent.bounds is accessed
         THEN the result contains the values of those datetimes
         """
-        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52) for n in range(5)]
-        dti1 = DateTimeInterval(start=datetime(2020, 12, 30), duration=Duration(days=1))
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
+        dti1 = DateTimeInterval(start=datetime(
+            2020, 12, 30), duration=Duration(days=1))
         dti2 = DateTimeInterval(start=dti1.end, duration=Duration(days=2))
         dti3 = DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 2, 1))
 
@@ -190,7 +195,8 @@ class TemporalExtentTest(unittest.TestCase):
         THEN the result contains the start value of the earliest DateTimeInterval and end value of the latest
              DateTimeInterval
         """
-        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52) for n in range(5)]
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
         dti1 = DateTimeInterval(end=datetimes[0], duration=Duration(days=1))
         dti2 = DateTimeInterval(start=datetimes[-1], duration=Duration(days=2))
         dti3 = DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 2, 1))
@@ -211,8 +217,10 @@ class TemporalExtentTest(unittest.TestCase):
         THEN the result contains the earliest datetime and end value of the latest
              DateTimeInterval
         """
-        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52) for n in range(5)]
-        dti1 = DateTimeInterval(start=datetime(2020, 12, 30), duration=Duration(days=1))
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
+        dti1 = DateTimeInterval(start=datetime(
+            2020, 12, 30), duration=Duration(days=1))
         dti2 = DateTimeInterval(end=datetimes[-1], duration=Duration(days=2))
         dti3 = DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 2, 1))
 
@@ -231,7 +239,8 @@ class TemporalExtentTest(unittest.TestCase):
         WHEN TemporalExtent.bounds is accessed
         THEN the result contains the earliest datetime and None
         """
-        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52) for n in range(5)]
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
         dti1 = DateTimeInterval(start=datetime(2020, 12, 30), duration=Duration(days=1),
                                 recurrences=DateTimeInterval.INFINITE_RECURRENCES)
         dti2 = DateTimeInterval(end=datetimes[-1], duration=Duration(days=2))
@@ -252,8 +261,10 @@ class TemporalExtentTest(unittest.TestCase):
         WHEN TemporalExtent.bounds is accessed
         THEN the result contains the start value of the earliest DateTimeInterval and the latest datetime
         """
-        datetimes = [datetime(2020, 12, 1) + timedelta(weeks=n * 52) for n in range(5)]
-        dti1 = DateTimeInterval(start=datetime(2020, 12, 30), duration=Duration(days=1))
+        datetimes = [datetime(2020, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
+        dti1 = DateTimeInterval(start=datetime(
+            2020, 12, 30), duration=Duration(days=1))
         dti2 = DateTimeInterval(start=dti1.end, duration=Duration(days=2))
         dti3 = DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 2, 1))
 
@@ -272,7 +283,8 @@ class TemporalExtentTest(unittest.TestCase):
         WHEN TemporalExtent.bounds is accessed
         THEN the result contains None and the latest datetime
         """
-        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52) for n in range(5)]
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
         dti1 = DateTimeInterval(end=datetime(2020, 12, 30), duration=Duration(days=1),
                                 recurrences=DateTimeInterval.INFINITE_RECURRENCES)
         dti2 = DateTimeInterval(start=dti1.end, duration=Duration(days=2))
@@ -294,9 +306,11 @@ class TemporalExtentTest(unittest.TestCase):
 
         Explicitly testing the case where a single DateTimeInterval provides both the upper and lower bound
         """
-        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52) for n in range(5)]
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
         # DateTimeInterval with only a duration and infinite recurrences implies unbounded lower and upper bounds
-        dti1 = DateTimeInterval(duration=Duration(days=1), recurrences=DateTimeInterval.INFINITE_RECURRENCES)
+        dti1 = DateTimeInterval(duration=Duration(
+            days=1), recurrences=DateTimeInterval.INFINITE_RECURRENCES)
         dti2 = DateTimeInterval(start=dti1.end, duration=Duration(days=2))
         dti3 = DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 2, 1))
 
@@ -316,11 +330,13 @@ class TemporalExtentTest(unittest.TestCase):
 
         Explicitly testing the case where a single DateTimeInterval provides both the upper and lower bound
         """
-        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52) for n in range(5)]
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
         # DateTimeInterval with only a duration and infinite recurrences implies unbounded lower and upper bounds
         dti1 = DateTimeInterval(start=datetimes[0] - timedelta(days=1),
                                 end=datetimes[-1] + timedelta(days=1))
-        dti2 = DateTimeInterval(start=datetimes[0] + timedelta(days=1), duration=Duration(days=2))
+        dti2 = DateTimeInterval(
+            start=datetimes[0] + timedelta(days=1), duration=Duration(days=2))
         dti3 = DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 2, 1))
 
         expected_bounds = dti1.start, dti1.end
@@ -329,6 +345,77 @@ class TemporalExtentTest(unittest.TestCase):
         extent = TemporalExtent(values=datetimes, intervals=[dti1, dti2, dti3])
 
         self.assertEqual(expected_bounds, extent.bounds)
+
+    def test_init_type_checking_values(self):
+        """
+        GIVEN a non-list
+        WHEN passed to TemporalExtent.values
+        THEN a TypeError is returned
+        Added due to https://metoffice.atlassian.net/browse/CAP-364
+        """
+        datetimes = {"value": datetime(2019, 12, 1)}
+
+        with self.assertRaisesRegex(TypeError, "Expected List of values, received <class 'dict'>"):
+            TemporalExtent(values=datetimes)
+
+    def test_init_type_checking_intervals(self):
+        """
+        GIVEN a non-list
+        WHEN passed to TemporalExtent.intervals
+        THEN a TypeError is returned
+        Added due to https://metoffice.atlassian.net/browse/CAP-364
+        """
+        dti = DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 12, 30))
+
+        with self.assertRaisesRegex(TypeError,
+                                    "Expected List of intervals, received <class 'edr_server.core.models.time.DateTimeInterval'>"):
+            TemporalExtent(intervals=dti)
+
+    def test_init_type_checking_values_entry(self):
+        """
+        GIVEN a list of datetimes with one bad entry
+        WHEN passed to TemporalExtent.values
+        THEN a TypeError is returned with value and type
+        Added due to https://metoffice.atlassian.net/browse/CAP-364
+        """
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
+        dti = [DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 12, 30))]
+        datetimes.append(1)
+
+        with self.assertRaisesRegex(TypeError, "Expected all datetime values, received value '1' of type <class 'int'>"):
+            TemporalExtent(values=datetimes, intervals=dti)
+
+    def test_init_type_checking_intervals_entry(self):
+        """
+        GIVEN a list of DatetimeIntervals with one bad entry
+        WHEN passed to TemporalExtent.intervals
+        THEN a TypeError is returned with value and type
+        Added due to https://metoffice.atlassian.net/browse/CAP-364
+        """
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
+        dti1 = DateTimeInterval(datetime(2020, 1, 1), datetime(2020, 12, 30))
+        dti2 = datetime(2021, 1, 1)
+
+        with self.assertRaisesRegex(TypeError,
+                                    "Expected all DateTimeIntervals, received value '2021-01-01 00:00:00' of type <class 'datetime.datetime'>"):
+            TemporalExtent(values=datetimes, intervals=[dti1, dti2])
+
+    def test_init_type_checking_trs(self):
+        """
+        GIVEN a non-CrsObject input
+        WHEN passed to TemporalExtent
+        THEN a TypeError is returned
+        Added due to https://metoffice.atlassian.net/browse/CAP-364
+        """
+        datetimes = [datetime(2019, 12, 1) + timedelta(weeks=n * 52)
+                     for n in range(5)]
+        input = "bad input"
+
+        with self.assertRaisesRegex(TypeError, "Expected CrsObject, received <class 'str'>"):
+            TemporalExtent(values=datetimes, trs=input)
+
 
 class SpatialExtentTest(unittest.TestCase):
 

--- a/tests/unit/core/models/test_parameters.py
+++ b/tests/unit/core/models/test_parameters.py
@@ -1,0 +1,22 @@
+import unittest
+from edr_server.core.models.i18n import LanguageMap
+from edr_server.core.models.parameters import Unit
+
+class UnitTest(unittest.TestCase):
+
+    def test_from_json(self):
+        """
+        GIVEN a Unit with a LanguageMap label
+        WHEN from_json() is called
+        THEN the expected Unit is returned
+        Added in response to this conversation:
+        https://github.com/MetOffice/edr_server/pull/35#discussion_r1008271136
+        """
+        expected = Unit(labels={"en": "foo"})
+
+        unit = Unit(labels=LanguageMap(en="foo"))
+        json_dict = {'label': {"en": "foo"}}
+
+        actual = unit.from_json(json_dict)
+
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
Added type checking to `TemporalExtent` class with accompanying tests, in response to [this ticket](https://metoffice.atlassian.net/browse/CAP-364).

Slightly more complex than the type checking for `SpatialExtent` in order to give hopefully useful context to the error messages!
Formatter has also been applied, hence scattering of indentation changes, etc.